### PR TITLE
Hardcode KTX version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.10.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
 }


### PR DESCRIPTION
This fixes a build error by hardcoding the KTX version to be compatible with other gradle/kotlin versions hardcoded in build.gradle. Otherwise this fails when the latest KTX is pulled.

